### PR TITLE
Data sourcing and init EDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # Ignoring Local Data Files - These can be sourced and created using scripts in the repo
 *.csv
-*.db
 *.parquet
 *.zip
 
+# Ignoring datatypes used by DuckDB
+*.db
+*.wal
+
 # Ignoring VSCode Workspace
 *.code-Workspace
-

--- a/dev_notebooks/dataset_config.ipynb
+++ b/dev_notebooks/dataset_config.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "from kaggle import KaggleApi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Using Kaggle Python API to source dataset from Kaggle\n",
+    "kaggle = KaggleApi()\n",
+    "kaggle.authenticate()\n",
+    "kaggle.dataset_download_file(dataset='dubradave/formula-1-drivers-dataset',\n",
+    "                             file_name='F1DriversDataset.csv',\n",
+    "                             path='/repos/FormulaOne-DataViz/data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using DuckDB to ingest data from csv into a Relation\n",
+    "duckdb.read_csv('../data/F1DriversDataset.csv')\n",
+    "\n",
+    "# Connecting to (Creating is not exists) DuckDB persistent dataset\n",
+    "con = duckdb.connect('FormulaOne.db')\n",
+    "\n",
+    "# Saving dataset back out to a DuckDB table 'FormulaOne_Drivers'\n",
+    "con.sql(f'''CREATE TABLE FormulaOne_Drivers AS\n",
+    "           SELECT * FROM \"../data/F1DriversDataset.csv\"\n",
+    "         ''')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dviz",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/dev_notebooks/dataset_config.ipynb
+++ b/dev_notebooks/dataset_config.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,13 +45,20 @@
     "duckdb.read_csv('../data/F1DriversDataset.csv')\n",
     "\n",
     "# Connecting to (Creating is not exists) DuckDB persistent dataset\n",
-    "con = duckdb.connect('FormulaOne.db')\n",
+    "con = duckdb.connect('../data/FormulaOne.db')\n",
     "\n",
     "# Saving dataset back out to a DuckDB table 'FormulaOne_Drivers'\n",
     "con.sql(f'''CREATE TABLE FormulaOne_Drivers AS\n",
     "           SELECT * FROM \"../data/F1DriversDataset.csv\"\n",
     "         ''')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/dev_notebooks/init_eda.ipynb
+++ b/dev_notebooks/init_eda.ipynb
@@ -1,0 +1,5847 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "\n",
+    "# pandas display option adjustments\n",
+    "pd.set_option('display.max_rows', None)\n",
+    "pd.set_option('display.max_columns', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Using Kaggle's python API to download dataset for project.\n",
+    "kaggle = KaggleApi()\n",
+    "kaggle.authenticate() # See Kaggle API instructions on how to set authentication in .kaggle/kaggle.json\n",
+    "kaggle.dataset_download_file(dataset='dubradave/formula-1-drivers-dataset',\n",
+    "                             file_name='F1DriversDataset.csv',\n",
+    "                             path='/repos/f1-duckdb/data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Driver</th>\n",
+       "      <th>Nationality</th>\n",
+       "      <th>Seasons</th>\n",
+       "      <th>Championships</th>\n",
+       "      <th>Race_Entries</th>\n",
+       "      <th>Race_Starts</th>\n",
+       "      <th>Pole_Positions</th>\n",
+       "      <th>Race_Wins</th>\n",
+       "      <th>Podiums</th>\n",
+       "      <th>Fastest_Laps</th>\n",
+       "      <th>Points</th>\n",
+       "      <th>Active</th>\n",
+       "      <th>Championship Years</th>\n",
+       "      <th>Decade</th>\n",
+       "      <th>Pole_Rate</th>\n",
+       "      <th>Start_Rate</th>\n",
+       "      <th>Win_Rate</th>\n",
+       "      <th>Podium_Rate</th>\n",
+       "      <th>FastLap_Rate</th>\n",
+       "      <th>Points_Per_Entry</th>\n",
+       "      <th>Years_Active</th>\n",
+       "      <th>Champion</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Carlo Abate</td>\n",
+       "      <td>Italy</td>\n",
+       "      <td>[1962, 1963]</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1960</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>George Abecassis</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>[1951, 1952]</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1950</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Kenny Acheson</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>[1983, 1985]</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1980</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.300000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Andrea de Adamich</td>\n",
+       "      <td>Italy</td>\n",
+       "      <td>[1968, 1970, 1971, 1972, 1973]</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>36.0</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1970</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.833333</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.166667</td>\n",
+       "      <td>5</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Philippe Adams</td>\n",
+       "      <td>Belgium</td>\n",
+       "      <td>[1994]</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1990</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              Driver     Nationality                         Seasons  \\\n",
+       "0        Carlo Abate           Italy                    [1962, 1963]   \n",
+       "1   George Abecassis  United Kingdom                    [1951, 1952]   \n",
+       "2      Kenny Acheson  United Kingdom                    [1983, 1985]   \n",
+       "3  Andrea de Adamich           Italy  [1968, 1970, 1971, 1972, 1973]   \n",
+       "4     Philippe Adams         Belgium                          [1994]   \n",
+       "\n",
+       "   Championships  Race_Entries  Race_Starts  Pole_Positions  Race_Wins  \\\n",
+       "0            0.0           3.0          0.0             0.0        0.0   \n",
+       "1            0.0           2.0          2.0             0.0        0.0   \n",
+       "2            0.0          10.0          3.0             0.0        0.0   \n",
+       "3            0.0          36.0         30.0             0.0        0.0   \n",
+       "4            0.0           2.0          2.0             0.0        0.0   \n",
+       "\n",
+       "   Podiums  Fastest_Laps  Points  Active Championship Years  Decade  \\\n",
+       "0      0.0           0.0     0.0   False                NaN    1960   \n",
+       "1      0.0           0.0     0.0   False                NaN    1950   \n",
+       "2      0.0           0.0     0.0   False                NaN    1980   \n",
+       "3      0.0           0.0     6.0   False                NaN    1970   \n",
+       "4      0.0           0.0     0.0   False                NaN    1990   \n",
+       "\n",
+       "   Pole_Rate  Start_Rate  Win_Rate  Podium_Rate  FastLap_Rate  \\\n",
+       "0        0.0    0.000000       0.0          0.0           0.0   \n",
+       "1        0.0    1.000000       0.0          0.0           0.0   \n",
+       "2        0.0    0.300000       0.0          0.0           0.0   \n",
+       "3        0.0    0.833333       0.0          0.0           0.0   \n",
+       "4        0.0    1.000000       0.0          0.0           0.0   \n",
+       "\n",
+       "   Points_Per_Entry  Years_Active  Champion  \n",
+       "0          0.000000             2     False  \n",
+       "1          0.000000             2     False  \n",
+       "2          0.000000             2     False  \n",
+       "3          0.166667             5     False  \n",
+       "4          0.000000             1     False  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Connecting to local DuckDB dataset\n",
+    "con = duckdb.connect(database='../data/FormulaOne.db')\n",
+    "\n",
+    "# Sourcing data from DuckDb into pandas dataframe\n",
+    "df = con.execute('''SELECT * FROM FormulaOne_Drivers''').fetch_df()\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Driver                 object\n",
+       " Nationality            object\n",
+       " Seasons                object\n",
+       " Championships         float64\n",
+       " Race_Entries          float64\n",
+       " Race_Starts           float64\n",
+       " Pole_Positions        float64\n",
+       " Race_Wins             float64\n",
+       " Podiums               float64\n",
+       " Fastest_Laps          float64\n",
+       " Points                float64\n",
+       " Active                   bool\n",
+       " Championship Years     object\n",
+       " Decade                  int64\n",
+       " Pole_Rate             float64\n",
+       " Start_Rate            float64\n",
+       " Win_Rate              float64\n",
+       " Podium_Rate           float64\n",
+       " FastLap_Rate          float64\n",
+       " Points_Per_Entry      float64\n",
+       " Years_Active            int64\n",
+       " Champion                 bool\n",
+       " dtype: object,\n",
+       " Index(['Driver', 'Nationality', 'Seasons', 'Championships', 'Race_Entries',\n",
+       "        'Race_Starts', 'Pole_Positions', 'Race_Wins', 'Podiums', 'Fastest_Laps',\n",
+       "        'Points', 'Active', 'Championship Years', 'Decade', 'Pole_Rate',\n",
+       "        'Start_Rate', 'Win_Rate', 'Podium_Rate', 'FastLap_Rate',\n",
+       "        'Points_Per_Entry', 'Years_Active', 'Champion'],\n",
+       "       dtype='object'))"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.dtypes, df.columns"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exploring Driver x Nationality\n",
+    "\n",
+    "Using DuckDB to query the F1 Driver Dataset that was importing into memory as a pandas pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drv_nat = duckdb.sql('''SELECT Count(Distinct(Driver)) as Driver_Cnt, Nationality\n",
+    "                        FROM df\n",
+    "                        GROUP BY Nationality\n",
+    "                        ORDER BY Driver_Cnt DESC''').df()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using plotly express to plot Driver Counts by Nationality\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "",
+         "marker": {
+          "color": "#636efa",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "",
+         "offsetgroup": "",
+         "orientation": "v",
+         "showlegend": false,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "United Kingdom",
+          "United States",
+          "Italy",
+          "France",
+          "West Germany",
+          "Brazil",
+          "Argentina",
+          "Switzerland",
+          "Belgium",
+          "South Africa",
+          "Japan",
+          "Australia",
+          "Netherlands",
+          "Austria",
+          "Spain",
+          "Canada",
+          "Germany",
+          "Sweden",
+          "New Zealand",
+          "Finland",
+          "Mexico",
+          "Portugal",
+          "Denmark",
+          "Ireland",
+          "Monaco",
+          "Uruguay",
+          "Rhodesia",
+          "Venezuela",
+          "East Germany",
+          "Colombia",
+          "Russia",
+          "Thailand",
+          "India",
+          "East Germany, West Germany",
+          "Hungary",
+          "Monaco Netherlands",
+          "Czech Republic",
+          "Belgium France",
+          "Indonesia",
+          "Rhodesia and Nyasaland",
+          "Poland",
+          "RAF",
+          "Liechtenstein",
+          "Chile",
+          "Malaysia",
+          "China",
+          "Morocco"
+         ],
+         "xaxis": "x",
+         "y": [
+          164,
+          160,
+          99,
+          72,
+          39,
+          32,
+          25,
+          24,
+          23,
+          23,
+          21,
+          18,
+          16,
+          16,
+          15,
+          15,
+          14,
+          11,
+          9,
+          9,
+          6,
+          5,
+          5,
+          5,
+          4,
+          4,
+          4,
+          3,
+          3,
+          3,
+          3,
+          2,
+          2,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "barmode": "relative",
+        "legend": {
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "showlegend": false,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Driver Counts by Nationality"
+        },
+        "uniformtext": {
+         "minsize": 3,
+         "mode": "hide"
+        },
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {}
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Driver Count"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = px.bar(x=drv_nat['Nationality'], y=drv_nat['Driver_Cnt'], text_auto=True)\n",
+    "fig.update_traces(textposition='outside', textfont_size=10)\n",
+    "fig.update_layout(title='Driver Counts by Nationality',\n",
+    "                  yaxis_title='Driver Count',\n",
+    "                  xaxis_title=None,\n",
+    "                  showlegend=False,\n",
+    "                  uniformtext_minsize=3,\n",
+    "                  uniformtext_mode='hide')\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at the above chart, it looks like Germany is split into Germany and pre-unification West Germany/East Germany.   \n",
+    "Here, I will highlight the observations mentioned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=United Kingdom<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "United Kingdom",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "United Kingdom",
+         "offsetgroup": "United Kingdom",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "United Kingdom"
+         ],
+         "xaxis": "x",
+         "y": [
+          164
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=United States<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "United States",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "United States",
+         "offsetgroup": "United States",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "United States"
+         ],
+         "xaxis": "x",
+         "y": [
+          160
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Italy<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Italy",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Italy",
+         "offsetgroup": "Italy",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Italy"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=France<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "France",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "France",
+         "offsetgroup": "France",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "France"
+         ],
+         "xaxis": "x",
+         "y": [
+          72
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=West Germany<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "West Germany",
+         "marker": {
+          "color": "#00796B",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "West Germany",
+         "offsetgroup": "West Germany",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "West Germany"
+         ],
+         "xaxis": "x",
+         "y": [
+          39
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Brazil<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Brazil",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Brazil",
+         "offsetgroup": "Brazil",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Brazil"
+         ],
+         "xaxis": "x",
+         "y": [
+          32
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Argentina<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Argentina",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Argentina",
+         "offsetgroup": "Argentina",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Argentina"
+         ],
+         "xaxis": "x",
+         "y": [
+          25
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Switzerland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Switzerland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Switzerland",
+         "offsetgroup": "Switzerland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Switzerland"
+         ],
+         "xaxis": "x",
+         "y": [
+          24
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Belgium<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Belgium",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Belgium",
+         "offsetgroup": "Belgium",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Belgium"
+         ],
+         "xaxis": "x",
+         "y": [
+          23
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=South Africa<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "South Africa",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "South Africa",
+         "offsetgroup": "South Africa",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "South Africa"
+         ],
+         "xaxis": "x",
+         "y": [
+          23
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Japan<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Japan",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Japan",
+         "offsetgroup": "Japan",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Japan"
+         ],
+         "xaxis": "x",
+         "y": [
+          21
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Australia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Australia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Australia",
+         "offsetgroup": "Australia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Australia"
+         ],
+         "xaxis": "x",
+         "y": [
+          18
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Netherlands<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Netherlands",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Netherlands",
+         "offsetgroup": "Netherlands",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Netherlands"
+         ],
+         "xaxis": "x",
+         "y": [
+          16
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Austria<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Austria",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Austria",
+         "offsetgroup": "Austria",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Austria"
+         ],
+         "xaxis": "x",
+         "y": [
+          16
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Spain<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Spain",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Spain",
+         "offsetgroup": "Spain",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Spain"
+         ],
+         "xaxis": "x",
+         "y": [
+          15
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Canada<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Canada",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Canada",
+         "offsetgroup": "Canada",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Canada"
+         ],
+         "xaxis": "x",
+         "y": [
+          15
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Germany<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Germany",
+         "marker": {
+          "color": "#00796B",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Germany",
+         "offsetgroup": "Germany",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Germany"
+         ],
+         "xaxis": "x",
+         "y": [
+          14
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Sweden<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Sweden",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Sweden",
+         "offsetgroup": "Sweden",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Sweden"
+         ],
+         "xaxis": "x",
+         "y": [
+          11
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=New Zealand<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "New Zealand",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "New Zealand",
+         "offsetgroup": "New Zealand",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "New Zealand"
+         ],
+         "xaxis": "x",
+         "y": [
+          9
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Finland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Finland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Finland",
+         "offsetgroup": "Finland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Finland"
+         ],
+         "xaxis": "x",
+         "y": [
+          9
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Mexico<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Mexico",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Mexico",
+         "offsetgroup": "Mexico",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Mexico"
+         ],
+         "xaxis": "x",
+         "y": [
+          6
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Portugal<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Portugal",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Portugal",
+         "offsetgroup": "Portugal",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Portugal"
+         ],
+         "xaxis": "x",
+         "y": [
+          5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Denmark<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Denmark",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Denmark",
+         "offsetgroup": "Denmark",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Denmark"
+         ],
+         "xaxis": "x",
+         "y": [
+          5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Ireland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Ireland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Ireland",
+         "offsetgroup": "Ireland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Ireland"
+         ],
+         "xaxis": "x",
+         "y": [
+          5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Monaco<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Monaco",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Monaco",
+         "offsetgroup": "Monaco",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Monaco"
+         ],
+         "xaxis": "x",
+         "y": [
+          4
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Uruguay<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Uruguay",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Uruguay",
+         "offsetgroup": "Uruguay",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Uruguay"
+         ],
+         "xaxis": "x",
+         "y": [
+          4
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Rhodesia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Rhodesia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Rhodesia",
+         "offsetgroup": "Rhodesia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Rhodesia"
+         ],
+         "xaxis": "x",
+         "y": [
+          4
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Venezuela<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Venezuela",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Venezuela",
+         "offsetgroup": "Venezuela",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Venezuela"
+         ],
+         "xaxis": "x",
+         "y": [
+          3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=East Germany<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "East Germany",
+         "marker": {
+          "color": "#00796B",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "East Germany",
+         "offsetgroup": "East Germany",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "East Germany"
+         ],
+         "xaxis": "x",
+         "y": [
+          3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Colombia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Colombia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Colombia",
+         "offsetgroup": "Colombia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Colombia"
+         ],
+         "xaxis": "x",
+         "y": [
+          3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Russia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Russia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Russia",
+         "offsetgroup": "Russia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Russia"
+         ],
+         "xaxis": "x",
+         "y": [
+          3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Thailand<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Thailand",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Thailand",
+         "offsetgroup": "Thailand",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Thailand"
+         ],
+         "xaxis": "x",
+         "y": [
+          2
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=India<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "India",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "India",
+         "offsetgroup": "India",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "India"
+         ],
+         "xaxis": "x",
+         "y": [
+          2
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=East Germany, West Germany<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "East Germany, West Germany",
+         "marker": {
+          "color": "#00796B",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "East Germany, West Germany",
+         "offsetgroup": "East Germany, West Germany",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "East Germany, West Germany"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Hungary<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Hungary",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Hungary",
+         "offsetgroup": "Hungary",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Hungary"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Monaco Netherlands<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Monaco Netherlands",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Monaco Netherlands",
+         "offsetgroup": "Monaco Netherlands",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Monaco Netherlands"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Czech Republic<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Czech Republic",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Czech Republic",
+         "offsetgroup": "Czech Republic",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Czech Republic"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Belgium France<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Belgium France",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Belgium France",
+         "offsetgroup": "Belgium France",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Belgium France"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Indonesia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Indonesia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Indonesia",
+         "offsetgroup": "Indonesia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Indonesia"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Rhodesia and Nyasaland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Rhodesia and Nyasaland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Rhodesia and Nyasaland",
+         "offsetgroup": "Rhodesia and Nyasaland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Rhodesia and Nyasaland"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Poland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Poland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Poland",
+         "offsetgroup": "Poland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Poland"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=RAF<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "RAF",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "RAF",
+         "offsetgroup": "RAF",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "RAF"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Liechtenstein<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Liechtenstein",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Liechtenstein",
+         "offsetgroup": "Liechtenstein",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Liechtenstein"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Chile<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Chile",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Chile",
+         "offsetgroup": "Chile",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Chile"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Malaysia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Malaysia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Malaysia",
+         "offsetgroup": "Malaysia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Malaysia"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=China<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "China",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "China",
+         "offsetgroup": "China",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "China"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Morocco<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Morocco",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Morocco",
+         "offsetgroup": "Morocco",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Morocco"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "barmode": "relative",
+        "legend": {
+         "title": {
+          "text": "color"
+         },
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "showlegend": false,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Driver Counts by Nationality - Highlight Germany Versions"
+        },
+        "uniformtext": {
+         "minsize": 3,
+         "mode": "hide"
+        },
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {}
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Driver Count"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lowlight = '#CFD8DC'\n",
+    "highlight = '#00796B'\n",
+    "country_highlighter = (\n",
+    "    [highlight if i in ['Germany','West Germany','East Germany','East Germany, West Germany'] \n",
+    "     else lowlight for i in drv_nat['Nationality']]\n",
+    ")\n",
+    "\n",
+    "fig = px.bar(x=drv_nat['Nationality'], y=drv_nat['Driver_Cnt'], \n",
+    "             text_auto=True, color_discrete_sequence=country_highlighter, color=drv_nat['Nationality'])\n",
+    "fig.update_traces(textposition='outside', textfont_size=10)\n",
+    "fig.update_layout(title='Driver Counts by Nationality - Highlight Germany Versions',\n",
+    "                  yaxis_title='Driver Count',\n",
+    "                  xaxis_title=None,\n",
+    "                  showlegend=False,\n",
+    "                  uniformtext_minsize=3,\n",
+    "                  uniformtext_mode='hide')\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looks like Germany is split into 4 buckets. For the sake of this analysis, Im going to rebucket them into a single Germany node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drv_nat_one_germany = duckdb.sql('''SELECT \n",
+    "                                        Count(Distinct(Driver)) as Driver_Cnt, \n",
+    "                                        CASE WHEN Nationality IN (\n",
+    "                                            'Germany','West Germany','East Germany',\n",
+    "                                            'East Germany, West Germany') THEN 'Germany'\n",
+    "                                             ELSE Nationality\n",
+    "                                             END AS Nationality_Corr\n",
+    "                                    FROM df\n",
+    "                                    GROUP BY Nationality_Corr\n",
+    "                                    ORDER BY Driver_Cnt DESC''').df()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=United Kingdom<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "United Kingdom",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "United Kingdom",
+         "offsetgroup": "United Kingdom",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "United Kingdom"
+         ],
+         "xaxis": "x",
+         "y": [
+          164
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=United States<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "United States",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "United States",
+         "offsetgroup": "United States",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "United States"
+         ],
+         "xaxis": "x",
+         "y": [
+          160
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Italy<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Italy",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Italy",
+         "offsetgroup": "Italy",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Italy"
+         ],
+         "xaxis": "x",
+         "y": [
+          99
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=France<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "France",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "France",
+         "offsetgroup": "France",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "France"
+         ],
+         "xaxis": "x",
+         "y": [
+          72
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Germany<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Germany",
+         "marker": {
+          "color": "#00796B",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Germany",
+         "offsetgroup": "Germany",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Germany"
+         ],
+         "xaxis": "x",
+         "y": [
+          57
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Brazil<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Brazil",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Brazil",
+         "offsetgroup": "Brazil",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Brazil"
+         ],
+         "xaxis": "x",
+         "y": [
+          32
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Argentina<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Argentina",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Argentina",
+         "offsetgroup": "Argentina",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Argentina"
+         ],
+         "xaxis": "x",
+         "y": [
+          25
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Switzerland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Switzerland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Switzerland",
+         "offsetgroup": "Switzerland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Switzerland"
+         ],
+         "xaxis": "x",
+         "y": [
+          24
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Belgium<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Belgium",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Belgium",
+         "offsetgroup": "Belgium",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Belgium"
+         ],
+         "xaxis": "x",
+         "y": [
+          23
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=South Africa<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "South Africa",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "South Africa",
+         "offsetgroup": "South Africa",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "South Africa"
+         ],
+         "xaxis": "x",
+         "y": [
+          23
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Japan<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Japan",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Japan",
+         "offsetgroup": "Japan",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Japan"
+         ],
+         "xaxis": "x",
+         "y": [
+          21
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Australia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Australia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Australia",
+         "offsetgroup": "Australia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Australia"
+         ],
+         "xaxis": "x",
+         "y": [
+          18
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Netherlands<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Netherlands",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Netherlands",
+         "offsetgroup": "Netherlands",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Netherlands"
+         ],
+         "xaxis": "x",
+         "y": [
+          16
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Austria<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Austria",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Austria",
+         "offsetgroup": "Austria",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Austria"
+         ],
+         "xaxis": "x",
+         "y": [
+          16
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Spain<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Spain",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Spain",
+         "offsetgroup": "Spain",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Spain"
+         ],
+         "xaxis": "x",
+         "y": [
+          15
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Canada<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Canada",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Canada",
+         "offsetgroup": "Canada",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Canada"
+         ],
+         "xaxis": "x",
+         "y": [
+          15
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Sweden<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Sweden",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Sweden",
+         "offsetgroup": "Sweden",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Sweden"
+         ],
+         "xaxis": "x",
+         "y": [
+          11
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=New Zealand<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "New Zealand",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "New Zealand",
+         "offsetgroup": "New Zealand",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "New Zealand"
+         ],
+         "xaxis": "x",
+         "y": [
+          9
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Finland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Finland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Finland",
+         "offsetgroup": "Finland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Finland"
+         ],
+         "xaxis": "x",
+         "y": [
+          9
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Mexico<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Mexico",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Mexico",
+         "offsetgroup": "Mexico",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Mexico"
+         ],
+         "xaxis": "x",
+         "y": [
+          6
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Portugal<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Portugal",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Portugal",
+         "offsetgroup": "Portugal",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Portugal"
+         ],
+         "xaxis": "x",
+         "y": [
+          5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Denmark<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Denmark",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Denmark",
+         "offsetgroup": "Denmark",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Denmark"
+         ],
+         "xaxis": "x",
+         "y": [
+          5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Ireland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Ireland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Ireland",
+         "offsetgroup": "Ireland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Ireland"
+         ],
+         "xaxis": "x",
+         "y": [
+          5
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Monaco<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Monaco",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Monaco",
+         "offsetgroup": "Monaco",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Monaco"
+         ],
+         "xaxis": "x",
+         "y": [
+          4
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Uruguay<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Uruguay",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Uruguay",
+         "offsetgroup": "Uruguay",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Uruguay"
+         ],
+         "xaxis": "x",
+         "y": [
+          4
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Rhodesia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Rhodesia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Rhodesia",
+         "offsetgroup": "Rhodesia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Rhodesia"
+         ],
+         "xaxis": "x",
+         "y": [
+          4
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Venezuela<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Venezuela",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Venezuela",
+         "offsetgroup": "Venezuela",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Venezuela"
+         ],
+         "xaxis": "x",
+         "y": [
+          3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Colombia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Colombia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Colombia",
+         "offsetgroup": "Colombia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Colombia"
+         ],
+         "xaxis": "x",
+         "y": [
+          3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Russia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Russia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Russia",
+         "offsetgroup": "Russia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Russia"
+         ],
+         "xaxis": "x",
+         "y": [
+          3
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Thailand<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Thailand",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Thailand",
+         "offsetgroup": "Thailand",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Thailand"
+         ],
+         "xaxis": "x",
+         "y": [
+          2
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=India<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "India",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "India",
+         "offsetgroup": "India",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "India"
+         ],
+         "xaxis": "x",
+         "y": [
+          2
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Hungary<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Hungary",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Hungary",
+         "offsetgroup": "Hungary",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Hungary"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Monaco Netherlands<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Monaco Netherlands",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Monaco Netherlands",
+         "offsetgroup": "Monaco Netherlands",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Monaco Netherlands"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Czech Republic<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Czech Republic",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Czech Republic",
+         "offsetgroup": "Czech Republic",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Czech Republic"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Belgium France<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Belgium France",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Belgium France",
+         "offsetgroup": "Belgium France",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Belgium France"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Indonesia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Indonesia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Indonesia",
+         "offsetgroup": "Indonesia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Indonesia"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Rhodesia and Nyasaland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Rhodesia and Nyasaland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Rhodesia and Nyasaland",
+         "offsetgroup": "Rhodesia and Nyasaland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Rhodesia and Nyasaland"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Poland<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Poland",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Poland",
+         "offsetgroup": "Poland",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Poland"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=RAF<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "RAF",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "RAF",
+         "offsetgroup": "RAF",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "RAF"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Liechtenstein<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Liechtenstein",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Liechtenstein",
+         "offsetgroup": "Liechtenstein",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Liechtenstein"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Chile<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Chile",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Chile",
+         "offsetgroup": "Chile",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Chile"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Malaysia<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Malaysia",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Malaysia",
+         "offsetgroup": "Malaysia",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Malaysia"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=China<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "China",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "China",
+         "offsetgroup": "China",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "China"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        },
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "color=Morocco<br>x=%{x}<br>y=%{y}<extra></extra>",
+         "legendgroup": "Morocco",
+         "marker": {
+          "color": "#CFD8DC",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "Morocco",
+         "offsetgroup": "Morocco",
+         "orientation": "v",
+         "showlegend": true,
+         "textfont": {
+          "size": 10
+         },
+         "textposition": "outside",
+         "texttemplate": "%{y}",
+         "type": "bar",
+         "x": [
+          "Morocco"
+         ],
+         "xaxis": "x",
+         "y": [
+          1
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "barmode": "relative",
+        "legend": {
+         "title": {
+          "text": "color"
+         },
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "showlegend": false,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Driver Counts by Nationality - One Germany"
+        },
+        "uniformtext": {
+         "minsize": 3,
+         "mode": "hide"
+        },
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {}
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Driver Count"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "country_highlighter = (\n",
+    "    [highlight if i in ['Germany','West Germany','East Germany','East Germany, West Germany'] \n",
+    "     else lowlight for i in drv_nat_one_germany['Nationality_Corr']]\n",
+    ")\n",
+    "\n",
+    "fig = px.bar(x=drv_nat_one_germany['Nationality_Corr'], y=drv_nat_one_germany['Driver_Cnt'], \n",
+    "             text_auto=True, color_discrete_sequence=country_highlighter, color=drv_nat_one_germany['Nationality_Corr'])\n",
+    "fig.update_traces(textposition='outside', textfont_size=10)\n",
+    "fig.update_layout(title='Driver Counts by Nationality - One Germany',\n",
+    "                  yaxis_title='Driver Count',\n",
+    "                  xaxis_title=None,\n",
+    "                  showlegend=False,\n",
+    "                  uniformtext_minsize=3,\n",
+    "                  uniformtext_mode='hide')\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "db_venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Additions

- Added `dev_notebooks/dataset_config.ipynb`
  - Utilizes Kaggle to source `FormulaOne-Driver-Dataset` from Kaggle
  - Utilizes `DuckDB` to create a persistent `.db` file for later use.

- Added `dev_notebooks/init_eda.ipynb` 
  - Connected to DuckDB `data/FormulaOne.db`
  - Queried the `FormulaOne_Drivers` table in `FormulaOne.db` and converts results to pandas DataFrame
  - Documented initial exploration findings via `plotly` visualizations of Driver Counts by Nationality